### PR TITLE
Add script arg for only displaying vulns with a CVSS score higher than x

### DIFF
--- a/vulners.nse
+++ b/vulners.nse
@@ -75,7 +75,13 @@ function make_links(vulns)
 
         -- Sometimes it might happen, so check the score availability
         cvss_score = vuln._source.cvss and ("\t\t" .. vuln._source.cvss.score) or ""
-        output_str = string.format("%s\n\t%s", output_str, vuln._source.id .. cvss_score .. '\t\thttps://vulners.com/' .. vuln._source.type .. '/' .. vuln._source.id .. (is_exploit and '\t\t*EXPLOIT*' or ''))
+        if nmap.registry.args.mincvss then
+            if tonumber(nmap.registry.args.mincvss) <= tonumber(cvss_score) then
+                output_str = string.format("%s\n\t%s", output_str, vuln._source.id .. cvss_score .. '\t\thttps://vulners.com/' .. vuln._source.type .. '/' .. vuln._source.id .. (is_exploit and '\t\t*EXPLOIT*' or ''))
+            end
+        else
+            output_str = string.format("%s\n\t%s", output_str, vuln._source.id .. cvss_score .. '\t\thttps://vulners.com/' .. vuln._source.type .. '/' .. vuln._source.id .. (is_exploit and '\t\t*EXPLOIT*' or ''))
+        end
     end
     
     return output_str


### PR DESCRIPTION
Title says it all. E.g: ```--script-args mincvss=5```


```
PORT   STATE SERVICE REASON  VERSION
80/tcp open  http    syn-ack Apache httpd 2.2.15 ((CentOS))
|_http-server-header: Apache/2.2.15 (CentOS)
| vulners: 
|   cpe:/a:apache:http_server:2.2.15: 
| 	CVE-2011-3192		7.8		https://vulners.com/cve/CVE-2011-3192
| 	CVE-2017-7679		7.5		https://vulners.com/cve/CVE-2017-7679
| 	CVE-2017-7668		7.5		https://vulners.com/cve/CVE-2017-7668
| 	CVE-2013-2249		7.5		https://vulners.com/cve/CVE-2013-2249
| 	CVE-2017-3169		7.5		https://vulners.com/cve/CVE-2017-3169
| 	CVE-2017-3167		7.5		https://vulners.com/cve/CVE-2017-3167
| 	CVE-2012-0883		6.9		https://vulners.com/cve/CVE-2012-0883
| 	CVE-2013-1862		5.1		https://vulners.com/cve/CVE-2013-1862
| 	CVE-2011-3368		5.0		https://vulners.com/cve/CVE-2011-3368
| 	CVE-2013-6438		5.0		https://vulners.com/cve/CVE-2013-6438
| 	CVE-2014-0098		5.0		https://vulners.com/cve/CVE-2014-0098
| 	CVE-2012-4557		5.0		https://vulners.com/cve/CVE-2012-4557
| 	CVE-2014-0231		5.0		https://vulners.com/cve/CVE-2014-0231
| 	CVE-2010-1452		5.0		https://vulners.com/cve/CVE-2010-1452
|_	CVE-2010-2068		5.0		https://vulners.com/cve/CVE-2010-2068
```